### PR TITLE
JTACMonthCell의 monthView public으로 전환

### DIFF
--- a/Sources/JTAppleCalendar/JTACMonthCell.swift
+++ b/Sources/JTAppleCalendar/JTACMonthCell.swift
@@ -34,7 +34,7 @@ public protocol JTACCellMonthViewDelegate: class {
 }
 
 open class JTACMonthCell: UICollectionViewCell {
-    @IBOutlet var monthView: JTACCellMonthView?
+    @IBOutlet public var monthView: JTACCellMonthView?
     weak var delegate: JTACCellMonthViewDelegate?
     
     func setupWith(configurationParameters: ConfigurationParameters,


### PR DESCRIPTION
라이브러리에서 YearView를 main storyboard 용으로만 만든 것인지, 예시가 많이 없더라구요

sample project에서는 JTACMonthCell의 monthView를 storyboard로 outlet 걸어서 사용하는데,

DDiary3에서는 그게 힘들어 아예 public으로 전환하여 직접 initialize를 해주었습니다.

(DDiary3 연간화면 pr의 YearCalendarMonthCell initialize 부분을 보시면 됩니다.)

이렇게 해결하는게 맞나 싶지만 시간도 좀 촉박하고 이렇게 해결했네요,,
